### PR TITLE
Disallow guest user from changing Wifi settings

### DIFF
--- a/services/core/java/com/android/server/pm/UserManagerService.java
+++ b/services/core/java/com/android/server/pm/UserManagerService.java
@@ -256,6 +256,19 @@ public class UserManagerService extends IUserManager.Stub {
                 Log.w(LOG_TAG, "Unable to notify AppOpsService of UserRestrictions");
             }
         }
+        UserInfo currentGuestUser = null;
+        synchronized (mPackagesLock) {
+            currentGuestUser = findCurrentGuestUserLocked();
+        }
+        if (currentGuestUser != null && !hasUserRestriction(
+                UserManager.DISALLOW_CONFIG_WIFI, currentGuestUser.id)) {
+            // If a guest user currently exists, apply the DISALLOW_CONFIG_WIFI option
+            // to it, in case this guest was created in a previous version where this
+            // user restriction was not a default guest restriction.
+            Bundle userRestrictionsToSet = new Bundle();
+            userRestrictionsToSet.putBoolean(UserManager.DISALLOW_CONFIG_WIFI, true);
+            setUserRestrictions(userRestrictionsToSet, currentGuestUser.id);
+        }
     }
 
     @Override
@@ -472,6 +485,7 @@ public class UserManagerService extends IUserManager.Stub {
      */
     private void initDefaultGuestRestrictions() {
         if (mGuestRestrictions.isEmpty()) {
+            mGuestRestrictions.putBoolean(UserManager.DISALLOW_CONFIG_WIFI, true);
             mGuestRestrictions.putBoolean(UserManager.DISALLOW_OUTGOING_CALLS, true);
             mGuestRestrictions.putBoolean(UserManager.DISALLOW_SMS, true);
         }


### PR DESCRIPTION
Disallow existing and newly created guest users from
changing Wifi settings.

Ticket: CYNGNOS-2373
BUG: 27411179
TEST: Flashed device, switched to existing guest user, and verified
      that Wifi settings are disabled.
TEST: Flashed device, created new guest user, and verified that Wifi
      settings are disabled.

Change-Id: Ia1bf4cce0369017b62f69d317c7ab2e30e3949b3
(cherry picked from commit d385a6d95fc830ecc8d55937e9f46b14165d4b34)
